### PR TITLE
Fix Button closing tag spacing

### DIFF
--- a/app/page-components/about/about.tsx
+++ b/app/page-components/about/about.tsx
@@ -23,9 +23,9 @@ export default function About() {
           <p className="text-lg mb-xxsmall">{about.text_1}</p>
           <p className="text-lg">{about.text_2}</p>
 
-          <Button variant="primary" size="medium" className="w-fit mt-xsmall" onClick={() => scrollToSection("contact")}>
+          <Button variant="primary" size="medium" className="w-fit mt-xsmall" onClick={() => scrollToSection("contact") }>
             {about.button_text}
-          </ Button>
+          </Button>
         </Content>
       </div>
     </Section>

--- a/app/page-components/projects/projects.tsx
+++ b/app/page-components/projects/projects.tsx
@@ -43,7 +43,7 @@ export default function Projects() {
 
               <Button variant="primary" size="medium" className="w-fit mb-small" onClick={handleOpenModal}>
                 {projects.modals.button_text}
-              </ Button>
+              </Button>
             </div>
             <div className="w-fit h-fit">
               <Link


### PR DESCRIPTION
## Summary
- remove stray space in closing `<Button>` tag in About and Projects page components

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853e0e628e08321a21134048621529f