### PR TITLE
Fix padding comment typo

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -51,7 +51,7 @@ export default {
         medium: "3rem", // Custom class for medium padding 48px
         large: "4rem", // Custom class for large padding 64px
         xlarge: "6rem", // Custom class for xlarge padding 96px
-        xxlarge: "8rem", // Custom class for xlarge padding 128px
+        xxlarge: "8rem", // Custom class for xxlarge padding 128px
       },
       margin: {
         none: "0px",


### PR DESCRIPTION
## Summary
- remove README documentation section added previously
- retain the corrected comment for `xxlarge` padding in Tailwind config

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853d88c0d2083218f59f0640d480f33